### PR TITLE
write possibly emptied link to standard header

### DIFF
--- a/src/create.jl
+++ b/src/create.jl
@@ -98,7 +98,7 @@ function write_header(
         w += write_extended_header(out, extended, buf=buf)
     end
     # emit standard header
-    std_hdr = Header(hdr.path, hdr.type, hdr.mode, hdr.size, hdr.link)
+    std_hdr = Header(hdr.path, hdr.type, hdr.mode, hdr.size, link)
     w += write_standard_header(out, std_hdr, name=name, prefix=prefix, buf=buf)
 end
 


### PR DESCRIPTION
`link` is set to the empty string if it is too long and will be set in the extended header