### PR TITLE
create: only look at user exe bit for execuableness

### DIFF
--- a/src/create.jl
+++ b/src/create.jl
@@ -16,8 +16,7 @@ function write_tarball(
     elseif isfile(st)
         size = filesize(st)
         type = '0'
-        # TODO: git's executable criteria w/r/t user, group, other?
-        mode = iszero(filemode(st) & 0o111) ? 0o644 : 0o755
+        mode = iszero(filemode(st) & 0o100) ? 0o644 : 0o755
         link = ""
     elseif isdir(st)
         size = 0


### PR DESCRIPTION
Make sure we don't hit https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/527. See also https://github.com/JuliaLang/Pkg.jl/pull/1513 which should be the same criterion.