### PR TITLE
allow write into directory overwriting a symlink

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -49,23 +49,22 @@ function extract_tarball(
         end
         if hdr.type == :symlink
             push!(links, path)
+        else
+            delete!(links, path)
         end
         sys_path = joinpath(root, parts...)
+        # delete anything that's there already
+        ispath(sys_path) && rm(sys_path, force=true, recursive=true)
         # create the path
         if hdr.type == :directory
             mkpath(sys_path)
         else
-            if ispath(sys_path)
-                # delete and replace path
-                rm(sys_path, force=true, recursive=true)
-            else
-                dir = dirname(sys_path)
-                # ensure `dir` is a directory
-                st = stat(dir)
-                if !isdir(st)
-                    ispath(st) && rm(dir, force=true, recursive=true)
-                    mkpath(dir)
-                end
+            dir = dirname(sys_path)
+            # ensure `dir` is a directory
+            st = stat(dir)
+            if !isdir(st)
+                ispath(st) && rm(dir, force=true, recursive=true)
+                mkpath(dir)
             end
             hdr.type == :file && read_data(tar, sys_path, size=hdr.size)
             hdr.type == :symlink && symlink(hdr.link, sys_path)


### PR DESCRIPTION
I realized that a path should be removed from the links set if it a non-link overwrites a link. This fixes that logic and adds a test that exercises this issue:

- create `path` as a symlink
- overwrite `path` as a directory
- write `path/file` inside of that directory

Previously this triggered the "symlink ovewrite attack" detection since `path` was added to the links set and not removed when the symlink was replaced by a plain directory. Now `path` is removed from the links set when the symlink is replaced by a directory, so the write to `path/file` is allowed.

Admittedly, this is a weird thing for a tarball to do, but since it is safe, we may as well allow it for the sake of consistency.