### PR TITLE
add support for GNU long link and long name extensions

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -81,10 +81,10 @@ these checks and list all the the contents of the tar file whether `extract`
 would extract them or not. Beware that malicious tarballs can do all sorts of
 crafty and unexpected things to try to trick you into doing something bad.
 """
-function list(tarball::AbstractString; strict::Bool=true)
+function list(tarball::AbstractString; raw::Bool=false, strict::Bool=!raw)
     list_tarball_check(tarball)
     open(tarball) do io
-        list_tarball(io, strict=strict)
+        list_tarball(io, raw=raw, strict=strict)
     end
 end
 

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -77,8 +77,7 @@ function extract_tarball(
                 chmod(sys_path, mode | ((mode & 0o444) >> 2) | 0o100)
                 # TODO: use actual umask exec bits instead?
             end
-        else
-            # should already be caught by check_header
+        else # should already be caught by check_header
             error("unsupported tarball entry type: $(hdr.type)")
         end
     end
@@ -105,7 +104,8 @@ function read_header(io::IO; buf::Vector{UInt8} = Vector{UInt8}(undef, 512))
     hdr === nothing && error("premature end of tar file")
     return Header(
         something(path, hdr.path),
-        hdr.type, hdr.mode,
+        hdr.type,
+        hdr.mode,
         something(size, hdr.size),
         something(link, hdr.link),
     )
@@ -228,7 +228,7 @@ function read_data(
     file::IO;
     size::Integer,
     buf::Vector{UInt8} = Vector{UInt8}(undef, 512),
-)
+)::Nothing
     resize!(buf, 512)
     while size > 0
         r = readbytes!(tar, buf)
@@ -246,7 +246,7 @@ function read_data(
     file::String;
     size::Integer,
     buf::Vector{UInt8} = Vector{UInt8}(undef, 512),
-)
+)::Nothing
     open(file, write=true) do file′
         read_data(tar, file′, size=size, buf=buf)
     end

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -1,11 +1,15 @@
 function list_tarball(
     tar::IO;
-    strict::Bool = true,
+    raw::Bool = false,
+    strict::Bool = !raw,
     buf::Vector{UInt8} = Vector{UInt8}(undef, 512),
 )
+    raw && strict &&
+        error("`raw=true` and `strict=true` options are incompatible")
     headers = Header[]
+    read_hdr = raw ? read_standard_header : read_header
     while !eof(tar)
-        hdr = read_header(tar, buf=buf)
+        hdr = read_hdr(tar, buf=buf)
         hdr === nothing && break
         strict && check_header(hdr)
         push!(headers, hdr)

--- a/src/header.jl
+++ b/src/header.jl
@@ -89,7 +89,7 @@ function check_header(hdr::Header)
     occursin(r"(^|/)\.\.(/|$)", hdr.path) &&
         err("path contains '..' component")
     hdr.type in (:file, :symlink, :directory) ||
-        err("unsupported file type")
+        err("unsupported entry type")
     hdr.type ∉ (:hardlink, :symlink) && !isempty(hdr.link) &&
         err("non-link with link path")
     hdr.type == :symlink && hdr.size != 0 &&

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,7 +110,7 @@ end
             @test headers == open(Tar.list, pipeline(`bzip2 -c -9 $tarball`, `bzcat`))
         end
     end
-    # Skip `tar` tests when it doesn't exist or when we're on windows
+    # skip `tar` tests when it doesn't exist or when we're on windows
     if Sys.which("tar") != nothing && !Sys.iswindows()
         @testset "extract with `tar` command" begin
             root = mktempdir()


### PR DESCRIPTION
Closes https://github.com/JuliaLang/Tar.jl/issues/14 by adding support for reading and extracting GNU long link and long name extensions. These are non-POSIX, but since they're easy to support and GNU tar is so widely used, we might as well support them. This StackOverflow page has a bit more information about these extensions: https://stackoverflow.com/questions/2078778/what-exactly-is-the-gnu-tar-longlink-trick. It's pretty straightforward: a header entry of type `L` indicates that the data for that entry is the path name of the following standard entry plus a trailing NUL byte; a header entry of type `L` indicates that the data for that entry is the link path of the following standard entry plus a trailing NUL byte.