### PR TITLE
list: allow passing `raw` option with `tarball::IO`

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -88,7 +88,8 @@ function list(tarball::AbstractString; raw::Bool=false, strict::Bool=!raw)
     end
 end
 
-list(tarball::IO; strict::Bool=true) = list_tarball(tarball, strict=strict)
+list(tarball::IO; raw::Bool=false, strict::Bool=!raw) =
+    list_tarball(tarball, raw=raw, strict=strict)
 
 """
     extract(tarball, [ dir ]) -> dir


### PR DESCRIPTION
This is still an unofficial option, but it may as well be supported consistently in the API.