### PR TITLE
Windows: close temp handle before trying to delete temp file

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -53,11 +53,11 @@ function create(predicate::Function, dir::AbstractString)
     tarball, out = mktemp()
     try write_tarball(predicate, out, dir)
     catch
+        close(out)
         rm(tarball, force=true)
         rethrow()
-    finally
-        close(out)
     end
+    close(out)
     return tarball
 end
 


### PR DESCRIPTION
This is fine on UNIX but may fail on Windows.